### PR TITLE
fix leak in Lua.State.execute

### DIFF
--- a/src/lua.js
+++ b/src/lua.js
@@ -549,9 +549,11 @@ Lua.State.prototype.load = function(code, name, mode) {
 Lua.State.prototype.execute = function(code) {
 	var proxy = this.load(code);
 	var args = slice.call(arguments, 1);
-	var res = proxy.invoke(args);
-	proxy.free();
-	return res;
+	try {
+		return proxy.invoke(args);
+	} finally {
+		proxy.free();
+	}
 };
 
 Lua.Proxy = function (L, i) {

--- a/src/lua.js
+++ b/src/lua.js
@@ -549,7 +549,9 @@ Lua.State.prototype.load = function(code, name, mode) {
 Lua.State.prototype.execute = function(code) {
 	var proxy = this.load(code);
 	var args = slice.call(arguments, 1);
-	return proxy.invoke(args);
+	var res = proxy.invoke(args);
+	proxy.free();
+	return res;
 };
 
 Lua.Proxy = function (L, i) {


### PR DESCRIPTION
Lua.State.execute creates a proxy whose ref is never released.